### PR TITLE
Added a 'See also' line to the random method.

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -789,6 +789,10 @@ You may optionally pass an integer to `random`. If that integer is more than `1`
     $random->all();
 
     // [2, 4, 5] - (retrieved randomly)
+    
+See also:
+
+[`shuffle`](#method-shuffle) - randomly shuffles the items in the collection
 
 <a name="method-reduce"></a>
 #### `reduce()` {#collection-method}


### PR DESCRIPTION
Added 'See also' shuffle to random method.

This was due to me wanting the shuffle method but searched for random. A reference to also look at the shuffle method would have helped
This is following the style on the php.net documentation. 

If this style is accepted I'd be happy to apply this to the rest of the documentation.